### PR TITLE
Revert bbbadc7 and add setOnScreenMessage with keep-parameter

### DIFF
--- a/classes/Conf/class.xlvoConfGUI.php
+++ b/classes/Conf/class.xlvoConfGUI.php
@@ -78,7 +78,7 @@ class xlvoConfGUI extends xlvoGUI
         $xlvoConfFormGUI = new xlvoConfFormGUI($this);
         $xlvoConfFormGUI->setValuesByPost();
         if ($xlvoConfFormGUI->saveObject()) {
-            ilLiveVotingPlugin::sendSuccess($this->txt('msg_success'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', $this->txt('msg_success'), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         }
         self::dic()->ui()->mainTemplate()->setContent($xlvoConfFormGUI->getHTML());

--- a/classes/Results/class.xlvoResultsGUI.php
+++ b/classes/Results/class.xlvoResultsGUI.php
@@ -86,11 +86,6 @@ class xlvoResultsGUI extends xlvoGUI
         $this->buildFilters($table);
         $table->initFilter();
         $table->buildData($this->obj_id, $this->round->getId());
-        if (isset($_SESSION['onscreen_message'])) {
-            $message = $_SESSION['onscreen_message'];
-            self::dic()->ui()->mainTemplate()->setOnScreenMessage($message['type'], $message['msg']);
-            unset($_SESSION['onscreen_message']); // Limpiar el mensaje después de mostrarlo
-        }
         self::dic()->ui()->mainTemplate()->setContent($table->getHTML());
     }
 
@@ -159,7 +154,7 @@ class xlvoResultsGUI extends xlvoGUI
         $newRound->setObjId($this->obj_id);
         $newRound->store();
         self::dic()->ctrl()->setParameter($this, 'round_id', xlvoRound::getLatestRound($this->obj_id)->getId());
-        $_SESSION['onscreen_message'] = array('type' => 'success', 'msg' => self::plugin()->translate("common_new_round_created"));
+        ilLiveVotingPlugin::sendSuccess(self::plugin()->translate("common_new_round_created"), true);
         self::dic()->ctrl()->redirect($this, self::CMD_SHOW);
     }
 

--- a/classes/Results/class.xlvoResultsGUI.php
+++ b/classes/Results/class.xlvoResultsGUI.php
@@ -154,7 +154,7 @@ class xlvoResultsGUI extends xlvoGUI
         $newRound->setObjId($this->obj_id);
         $newRound->store();
         self::dic()->ctrl()->setParameter($this, 'round_id', xlvoRound::getLatestRound($this->obj_id)->getId());
-        ilLiveVotingPlugin::sendSuccess(self::plugin()->translate("common_new_round_created"), true);
+        self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("common_new_round_created"), true);
         self::dic()->ctrl()->redirect($this, self::CMD_SHOW);
     }
 

--- a/classes/Voter/class.xlvoVoter2GUI.php
+++ b/classes/Voter/class.xlvoVoter2GUI.php
@@ -147,7 +147,7 @@ class xlvoVoter2GUI extends xlvoGUI
             self::dic()->ctrl()->redirect($this, self::CMD_START_VOTER_PLAYER);
         } catch (xlvoVoterException $e) {
             $param_manager->setPin('');
-            ilLiveVotingPlugin::sendFailure($this->txt('msg_validation_error_pin_' . $e->getCode()));
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', $this->txt('msg_validation_error_pin_' . $e->getCode()), true);
             $this->index();
         }
     }

--- a/classes/Voting/class.xlvoVotingGUI.php
+++ b/classes/Voting/class.xlvoVotingGUI.php
@@ -111,7 +111,7 @@ class xlvoVotingGUI
     protected function content()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
         } elseif (ilObjLiveVotingAccess::hasWriteAccess()) {
             $b = ilLinkButton::getInstance();
             $b->setPrimary(true);
@@ -185,7 +185,7 @@ class xlvoVotingGUI
     protected function selectType(bool $error = false)
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             $form = new ilPropertyFormGUI();
@@ -220,7 +220,7 @@ class xlvoVotingGUI
     protected function add()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             $xlvoVoting = new xlvoVoting();
@@ -238,7 +238,7 @@ class xlvoVotingGUI
     protected function create()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             $xlvoVoting = new xlvoVoting();
@@ -246,7 +246,7 @@ class xlvoVotingGUI
             $xlvoVotingFormGUI = xlvoVotingFormGUI::get($this, $xlvoVoting);
             $xlvoVotingFormGUI->setValuesByPost();
             if ($xlvoVotingFormGUI->saveObject()) {
-                ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('msg_success_voting_created'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("msg_success_voting_created"), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
             self::dic()->ui()->mainTemplate()->setContent($xlvoVotingFormGUI->getHTML());
@@ -260,7 +260,7 @@ class xlvoVotingGUI
     protected function edit()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             /**
@@ -347,7 +347,7 @@ class xlvoVotingGUI
     protected function update($cmd = self::CMD_STANDARD)
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             $xlvoVoting = xlvoVoting::find($_GET[self::IDENTIFIER]);
@@ -355,7 +355,7 @@ class xlvoVotingGUI
             $xlvoVotingFormGUI = xlvoVotingFormGUI::get($this, $xlvoVoting);
             $xlvoVotingFormGUI->setValuesByPost();
             if ($xlvoVotingFormGUI->saveObject()) {
-                ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('msg_success_voting_updated'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("msg_success_voting_updated"), true);
                 self::dic()->ctrl()->redirect($this, $cmd);
             }
             self::dic()->ui()->mainTemplate()->setContent($xlvoVotingFormGUI->getHTML());
@@ -369,7 +369,7 @@ class xlvoVotingGUI
     protected function confirmDelete()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
 
@@ -388,7 +388,7 @@ class xlvoVotingGUI
 
                 self::dic()->ui()->mainTemplate()->setContent($confirm->getHTML());
             } else {
-                ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_object'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_object"), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
         }
@@ -401,7 +401,7 @@ class xlvoVotingGUI
     protected function delete()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
 
@@ -428,7 +428,7 @@ class xlvoVotingGUI
                 $xlvoVoting->delete();
                 $this->cancel();
             } else {
-                ilLiveVotingPlugin::sendFailure(self::plugin()->translate('delete_failed'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("delete_failed"), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
         }
@@ -441,7 +441,7 @@ class xlvoVotingGUI
     protected function confirmReset()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
 
@@ -451,7 +451,7 @@ class xlvoVotingGUI
             $xlvoVoting = xlvoVoting::find($_GET[self::IDENTIFIER]);
             if ($xlvoVoting->getObjId() == $this->getObjId()) {
 
-                ilLiveVotingPlugin::sendQuestion($this->txt('confirm_reset'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('question', $this->txt('confirm_reset'), true);
 
                 $confirm = new ilConfirmationGUI();
                 $confirm->addItem(self::IDENTIFIER, $xlvoVoting->getId(), $xlvoVoting->getTitle());
@@ -463,7 +463,7 @@ class xlvoVotingGUI
                 self::dic()->ui()->mainTemplate()->setContent($confirm->getHTML());
 
             } else {
-                ilLiveVotingPlugin::sendFailure($this->txt('permission_denied_object'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', $this->txt('permission_denied_object'), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
         }
@@ -476,7 +476,7 @@ class xlvoVotingGUI
     protected function reset()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             /**
@@ -495,7 +495,7 @@ class xlvoVotingGUI
                 }
                 $this->cancel();
             } else {
-                ilLiveVotingPlugin::sendFailure(self::plugin()->translate('reset_failed'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("reset_failed"), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
         }
@@ -508,7 +508,7 @@ class xlvoVotingGUI
     protected function confirmResetAll()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             //ilLiveVotingPlugin::sendQuestion($this->txt('confirm_reset_all'), true);
@@ -538,7 +538,7 @@ class xlvoVotingGUI
     protected function resetAll()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             /**
@@ -570,7 +570,7 @@ class xlvoVotingGUI
          */
         $xlvoVoting = xlvoVoting::find($_GET[self::IDENTIFIER]);
         $xlvoVoting->fullClone(true, true);
-        ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('voting_msg_duplicated'), true);
+        self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("voting_msg_duplicated"), true);
         $this->cancel();
     }
 
@@ -630,7 +630,7 @@ class xlvoVotingGUI
          */
         $xlvoVoting = xlvoVoting::find($_GET[self::IDENTIFIER]);
         $xlvoVoting->fullClone(true, true, $obj_id);
-        ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('voting_msg_duplicated'), true);
+        self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("voting_msg_duplicated"), true);
         $this->cancel();
     }
 
@@ -650,7 +650,7 @@ class xlvoVotingGUI
     protected function saveSorting()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("permission_denied_write"), true);
         } else {
             if (is_array($_POST['position'])) {
                 foreach ($_POST['position'] as $k => $v) {
@@ -662,7 +662,7 @@ class xlvoVotingGUI
                     $xlvoVoting->store();
                 }
             }
-            ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('voting_msg_sorting_saved'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("voting_msg_sorting_saved"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         }
     }

--- a/classes/Voting/class.xlvoVotingGUI.php
+++ b/classes/Voting/class.xlvoVotingGUI.php
@@ -174,11 +174,6 @@ class xlvoVotingGUI
                             . "_info_manual_" . $step)) . '</li>';
                 }, range(1, 4))) . '</ol>' : ''); // TODO: default.css not loaded
 
-            if (isset($_SESSION['onscreen_message'])) {
-                $message = $_SESSION['onscreen_message'];
-                self::dic()->ui()->mainTemplate()->setOnScreenMessage($message['type'], $message['msg']);
-                unset($_SESSION['onscreen_message']); // Limpiar el mensaje después de mostrarlo
-            }
             self::dic()->ui()->mainTemplate()->setContent($xlvoVotingTableGUI->getHTML() . $powerpoint_export);
         }
     }
@@ -251,8 +246,8 @@ class xlvoVotingGUI
             $xlvoVotingFormGUI = xlvoVotingFormGUI::get($this, $xlvoVoting);
             $xlvoVotingFormGUI->setValuesByPost();
             if ($xlvoVotingFormGUI->saveObject()) {
-                self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("msg_success_voting_created"));
-
+                ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('msg_success_voting_created'), true);
+                self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
             }
             self::dic()->ui()->mainTemplate()->setContent($xlvoVotingFormGUI->getHTML());
         }
@@ -360,8 +355,8 @@ class xlvoVotingGUI
             $xlvoVotingFormGUI = xlvoVotingFormGUI::get($this, $xlvoVoting);
             $xlvoVotingFormGUI->setValuesByPost();
             if ($xlvoVotingFormGUI->saveObject()) {
-                //ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('msg_success_voting_updated'), true);
-                self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("msg_success_voting_updated"));
+                ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('msg_success_voting_updated'), true);
+                self::dic()->ctrl()->redirect($this, $cmd);
             }
             self::dic()->ui()->mainTemplate()->setContent($xlvoVotingFormGUI->getHTML());
         }
@@ -575,7 +570,7 @@ class xlvoVotingGUI
          */
         $xlvoVoting = xlvoVoting::find($_GET[self::IDENTIFIER]);
         $xlvoVoting->fullClone(true, true);
-        $_SESSION['onscreen_message'] = array('type' => 'success', 'msg' => self::plugin()->translate('voting_msg_duplicated'));
+        ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('voting_msg_duplicated'), true);
         $this->cancel();
     }
 
@@ -667,7 +662,7 @@ class xlvoVotingGUI
                     $xlvoVoting->store();
                 }
             }
-            $_SESSION['onscreen_message'] = array('type' => 'success', 'msg' => self::plugin()->translate('voting_msg_sorting_saved'));
+            ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('voting_msg_sorting_saved'), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         }
     }

--- a/classes/class.ilObjLiveVotingGUI.php
+++ b/classes/class.ilObjLiveVotingGUI.php
@@ -321,7 +321,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
     public function editProperties()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('obj_permission_denied'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("obj_permission_denied"), true);
             self::dic()->ctrl()->redirect($this, self::CMD_STANDARD);
         } else {
             self::dic()->tabs()->activateTab(self::TAB_EDIT);
@@ -369,7 +369,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
     {
 
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('obj_permission_denied'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("obj_permission_denied"), true);
         } else {
             $this->form = new ilPropertyFormGUI();
             $this->form->setTitle(self::plugin()->translate('obj_edit_properties'));
@@ -466,7 +466,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
     public function updateProperties()
     {
         if (!ilObjLiveVotingAccess::hasWriteAccess()) {
-            ilLiveVotingPlugin::sendFailure(self::plugin()->translate('obj_permission_denied_write'), true);
+            self::dic()->ui()->mainTemplate()->setOnScreenMessage('failure', self::plugin()->translate("obj_permission_denied"), true);
         } else {
             self::dic()->tabs()->activateTab(self::TAB_EDIT);
             $this->initPropertiesForm();
@@ -499,7 +499,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
                 $config->setShowAttendees($this->form->getInput(xlvoVotingConfig::F_SHOW_ATTENDEES));
 
                 $config->store();
-                ilLiveVotingPlugin::sendSuccess(self::plugin()->translate('obj_msg_properties_form_saved'), true);
+                self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::plugin()->translate("obj_msg_properties_form_saved"), true);
                 self::dic()->ctrl()->redirect($this, self::CMD_EDIT);
             }
 
@@ -582,7 +582,7 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
     public function addToDeskObject(): void
     {
         ilDesktopItemGUI::addToDesktop();
-        ilLiveVotingPlugin::sendSuccess(self::dic()->language()->txt("added_to_desktop"));
+        self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::dic()->language()->txt("added_to_desktop"), true);
     }
 
 
@@ -592,6 +592,6 @@ class ilObjLiveVotingGUI extends ilObjectPluginGUI implements ilDesktopItemHandl
     public function removeFromDeskObject(): void
     {
         ilDesktopItemGUI::removeFromDesktop();
-        ilLiveVotingPlugin::sendSuccess(self::dic()->language()->txt("removed_from_desktop"));
+        self::dic()->ui()->mainTemplate()->setOnScreenMessage('success', self::dic()->language()->txt("removed_from_desktop"), true);
     }
 }


### PR DESCRIPTION
First of all, thank you for the great work that makes it possible to use the plugin under ILIAS8. I just have a small comment regarding the messages: it should not be necessary to modify the $_SESSION array to display the message after a redirect. There is a third parameter in the setOnScreenMessage method for this purpose, which can be set to true to keep the message:

```public function setOnScreenMessage(string $type, string $a_txt, bool $a_keep = false): void;```

This pull request reverts the commit bbbadc78e4cbb289556d6e659ba457fada4260de and adjusts the corresponding locations with setOnScreenMessage, where the message should be kept after a redirection.

Best regards
Ilja