### PR TITLE
added init function rbacadmin to fake init for pin.php #40994

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . "/vendor/srag/dic/src/PHPVersionChecker.php";
 
 $id = 'xlvo';
-$version = '2024.10.03';
+$version = '2024.10.08';
 $ilias_min_version = '8.0';
 $ilias_max_version = '8.999';
 $responsible = 'fluxlabs ag';

--- a/src/Context/Initialisation/Version/v7/xlvoBasicInitialisation.php
+++ b/src/Context/Initialisation/Version/v7/xlvoBasicInitialisation.php
@@ -157,11 +157,20 @@ class xlvoBasicInitialisation
         $this->initFilesystem();
         $this->initResourceStorage();
         $this->initGlobalScreen($GLOBALS["DIC"]);
+        $this->initRbacAdmin();
         $this->initTemplate();
         $this->initTabs();
         $this->initNavigationHistory();
         $this->initHelp();
         xlvoInitialisation::initUIFramework(self::dic()->dic());
+    }
+
+    /**
+     * Initialize a fake rbacadmin service to satisfy the help system module
+     */
+    private function initRbacAdmin(): void
+    {
+        $this->makeGlobal('rbacadmin', new \ilRbacAdmin());
     }
 
     /**


### PR DESCRIPTION
This fix might repair: https://mantis.ilias.de/view.php?id=40994

It looks like the LiveVoting Plugin initializes a ILIAS without user and rbac management (InitialisationManager) which later calls an rbac function from the PermissionManager. This results in "Identifier "rbacadmin" is not defined.".

If you do, however, a fake init-call it seems to work. Do you have any objections?